### PR TITLE
Fixes for registry binary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@kapeta/kap-command": "<2",
-        "@kapeta/local-cluster-config": "<2",
+        "@kapeta/local-cluster-config": ">=0.2.3 < 2",
         "@kapeta/nodejs-api-client": "^0.0.13",
         "@kapeta/nodejs-registry-utils": "<2",
         "@kapeta/nodejs-utils": "<2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@kapeta/kap-command": "<2",
-    "@kapeta/local-cluster-config": "<2",
+    "@kapeta/local-cluster-config": ">=0.2.3 < 2",
     "@kapeta/nodejs-api-client": "^0.0.13",
     "@kapeta/nodejs-registry-utils": "<2",
     "@kapeta/nodejs-utils": "<2",

--- a/registry.js
+++ b/registry.js
@@ -2,7 +2,7 @@
 const KapetaCommand = require('@kapeta/kap-command');
 const packageData = require('./package');
 const {Config} = require('@kapeta/nodejs-registry-utils');
-const ClusterConfiguration = require('@kapeta/local-cluster-config');
+const ClusterConfiguration = require('@kapeta/local-cluster-config').default;
 const command = new KapetaCommand(packageData.command, packageData.version);
 const program = command.program();
 const installer = require('./src/commands/install')


### PR DESCRIPTION
Fix for local-cluster-config use in registry command.
- fix: bump required api client version
- fix: tweak cluster-config import and set version
